### PR TITLE
Clarify is_image and dtype.

### DIFF
--- a/docs/api/geo_datasets.csv
+++ b/docs/api/geo_datasets.csv
@@ -1,6 +1,6 @@
 Dataset,Type,Source,License,Size (px),Resolution (m)
 `Aboveground Woody Biomass`_,Masks,"Landsat, LiDAR","CC-BY-4.0","40,000x40,000",30
-`Aster Global DEM`_,DEM,Aster,"public domain","3,601x3,601",30
+`Aster Global DEM`_,Masks,Aster,"public domain","3,601x3,601",30
 `Canadian Building Footprints`_,Geometries,Bing Imagery,"ODbL-1.0",-,-
 `Chesapeake Land Cover`_,"Imagery, Masks",NAIP,"CC-BY-4.0",-,1
 `Global Mangrove Distribution`_,Masks,"Remote Sensing, In Situ Measurements","public domain",-,3
@@ -8,7 +8,7 @@ Dataset,Type,Source,License,Size (px),Resolution (m)
 `EDDMapS`_,Points,Citizen Scientists,-,-,-
 `EnviroAtlas`_,"Imagery, Masks","NAIP, NLCD, OpenStreetMap","CC-BY-4.0",-,1
 `Esri2020`_,Masks,Sentinel-2,"CC-BY-4.0",-,10
-`EU-DEM`_,DEM,"Aster, SRTM, Russian Topomaps","CSCDA-ESA",-,25
+`EU-DEM`_,Masks,"Aster, SRTM, Russian Topomaps","CSCDA-ESA",-,25
 `GBIF`_,Points,Citizen Scientists,"CC0-1.0 OR CC-BY-4.0 OR CC-BY-NC-4.0",-,-
 `GlobBiomass`_,Masks,Landsat,"CC-BY-4.0","45,000x45,000",100
 `iNaturalist`_,Points,Citizen Scientists,-,-,-

--- a/tests/data/astergdem/data.py
+++ b/tests/data/astergdem/data.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
         # remove old data
         if os.path.exists(path):
             os.remove(path)
-        # Create image file
+        # Create mask file
         create_file(path, dtype="int32", num_channels=1)
         files_to_zip.append(path)
 

--- a/tests/data/eudem/data.py
+++ b/tests/data/eudem/data.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
         # remove old data
         if os.path.exists(path):
             os.remove(path)
-        # Create image file
+        # Create mask file
         create_file(path, dtype="int32", num_channels=1)
         files_to_zip.append(path)
 

--- a/tests/datasets/test_astergdem.py
+++ b/tests/datasets/test_astergdem.py
@@ -39,7 +39,7 @@ class TestAsterGDEM:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
         assert isinstance(x["crs"], CRS)
-        assert isinstance(x["image"], torch.Tensor)
+        assert isinstance(x["mask"], torch.Tensor)
 
     def test_and(self, dataset: AsterGDEM) -> None:
         ds = dataset & dataset
@@ -53,6 +53,13 @@ class TestAsterGDEM:
         query = dataset.bounds
         x = dataset[query]
         dataset.plot(x, suptitle="Test")
+        plt.close()
+
+    def test_plot_prediction(self, dataset: AsterGDEM) -> None:
+        query = dataset.bounds
+        x = dataset[query]
+        x["prediction"] = x["mask"].clone()
+        dataset.plot(x, suptitle="Prediction")
         plt.close()
 
     def test_invalid_query(self, dataset: AsterGDEM) -> None:

--- a/tests/datasets/test_eudem.py
+++ b/tests/datasets/test_eudem.py
@@ -36,7 +36,7 @@ class TestEUDEM:
         x = dataset[dataset.bounds]
         assert isinstance(x, dict)
         assert isinstance(x["crs"], CRS)
-        assert isinstance(x["image"], torch.Tensor)
+        assert isinstance(x["mask"], torch.Tensor)
 
     def test_extracted_already(self, dataset: EUDEM) -> None:
         assert isinstance(dataset.paths, str)
@@ -68,6 +68,13 @@ class TestEUDEM:
         query = dataset.bounds
         x = dataset[query]
         dataset.plot(x, suptitle="Test")
+        plt.close()
+
+    def test_plot_prediction(self, dataset: EUDEM) -> None:
+        query = dataset.bounds
+        x = dataset[query]
+        x["prediction"] = x["mask"].clone()
+        dataset.plot(x, suptitle="Prediction")
         plt.close()
 
     def test_invalid_query(self, dataset: EUDEM) -> None:

--- a/torchgeo/datasets/astergdem.py
+++ b/torchgeo/datasets/astergdem.py
@@ -37,7 +37,7 @@ class AsterGDEM(RasterDataset):
     .. versionadded:: 0.3
     """
 
-    is_image = True
+    is_image = False
     all_bands = ["elevation"]
     filename_glob = "ASTGTMV003_*_dem*"
     filename_regex = r"""

--- a/torchgeo/datasets/astergdem.py
+++ b/torchgeo/datasets/astergdem.py
@@ -6,7 +6,6 @@
 from typing import Any, Callable, Optional, Union
 
 import matplotlib.pyplot as plt
-import torch
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
 
@@ -38,7 +37,6 @@ class AsterGDEM(RasterDataset):
     """
 
     is_image = False
-    all_bands = ["elevation"]
     filename_glob = "ASTGTMV003_*_dem*"
     filename_regex = r"""
         (?P<name>[ASTGTMV003]{10})
@@ -76,11 +74,8 @@ class AsterGDEM(RasterDataset):
         self.paths = paths
 
         self._verify()
-        bands = self.all_bands
 
-        super().__init__(
-            paths, crs, res, bands=bands, transforms=transforms, cache=cache
-        )
+        super().__init__(paths, crs, res, transforms=transforms, cache=cache)
 
     def _verify(self) -> None:
         """Verify the integrity of the dataset."""
@@ -106,17 +101,29 @@ class AsterGDEM(RasterDataset):
         Returns:
             a matplotlib Figure with the rendered sample
         """
-        image = sample["image"][0]
+        mask = sample["mask"].squeeze()
+        ncols = 1
 
-        image = torch.clamp(image, min=0, max=1)
+        showing_predictions = "prediction" in sample
+        if showing_predictions:
+            prediction = sample["prediction"].squeeze()
+            ncols = 2
 
-        fig, ax = plt.subplots(1, 1, figsize=(4, 4))
+        fig, axs = plt.subplots(nrows=1, ncols=ncols, figsize=(4 * ncols, 4))
 
-        ax.imshow(image)
-        ax.axis("off")
-
-        if show_titles:
-            ax.set_title("Elevation")
+        if showing_predictions:
+            axs[0].imshow(mask)
+            axs[0].axis("off")
+            axs[1].imshow(prediction)
+            axs[1].axis("off")
+            if show_titles:
+                axs[0].set_title("Mask")
+                axs[1].set_title("Prediction")
+        else:
+            axs.imshow(mask)
+            axs.axis("off")
+            if show_titles:
+                axs.set_title("Mask")
 
         if suptitle is not None:
             plt.suptitle(suptitle)

--- a/torchgeo/datasets/eudem.py
+++ b/torchgeo/datasets/eudem.py
@@ -9,7 +9,6 @@ from collections.abc import Iterable
 from typing import Any, Callable, Optional, Union
 
 import matplotlib.pyplot as plt
-import torch
 from matplotlib.figure import Figure
 from rasterio.crs import CRS
 
@@ -48,7 +47,6 @@ class EUDEM(RasterDataset):
     """
 
     is_image = False
-    all_bands = ["elevation"]
     filename_glob = "eu_dem_v11_*.TIF"
     zipfile_glob = "eu_dem_v11_*[A-Z0-9].zip"
     filename_regex = "(?P<name>[eudem_v11]{10})_(?P<id>[A-Z0-9]{6})"
@@ -116,11 +114,8 @@ class EUDEM(RasterDataset):
         self.checksum = checksum
 
         self._verify()
-        bands = self.all_bands
 
-        super().__init__(
-            paths, crs, res, bands=bands, transforms=transforms, cache=cache
-        )
+        super().__init__(paths, crs, res, transforms=transforms, cache=cache)
 
     def _verify(self) -> None:
         """Verify the integrity of the dataset."""
@@ -157,17 +152,29 @@ class EUDEM(RasterDataset):
         Returns:
             a matplotlib Figure with the rendered sample
         """
-        image = sample["image"][0]
+        mask = sample["mask"].squeeze()
+        ncols = 1
 
-        image = torch.clamp(image, min=0, max=1)
+        showing_predictions = "prediction" in sample
+        if showing_predictions:
+            pred = sample["prediction"].squeeze()
+            ncols = 2
 
-        fig, ax = plt.subplots(1, 1, figsize=(4, 4))
+        fig, axs = plt.subplots(nrows=1, ncols=ncols, figsize=(ncols * 4, 4))
 
-        ax.imshow(image)
-        ax.axis("off")
-
-        if show_titles:
-            ax.set_title("Elevation")
+        if showing_predictions:
+            axs[0].imshow(mask)
+            axs[0].axis("off")
+            axs[1].imshow(pred)
+            axs[1].axis("off")
+            if show_titles:
+                axs[0].set_title("Mask")
+                axs[1].set_title("Prediction")
+        else:
+            axs.imshow(mask)
+            axs.axis("off")
+            if show_titles:
+                axs.set_title("Mask")
 
         if suptitle is not None:
             plt.suptitle(suptitle)

--- a/torchgeo/datasets/eudem.py
+++ b/torchgeo/datasets/eudem.py
@@ -47,7 +47,7 @@ class EUDEM(RasterDataset):
     .. versionadded:: 0.3
     """
 
-    is_image = True
+    is_image = False
     all_bands = ["elevation"]
     filename_glob = "eu_dem_v11_*.TIF"
     zipfile_glob = "eu_dem_v11_*[A-Z0-9].zip"

--- a/torchgeo/datasets/vhr10.py
+++ b/torchgeo/datasets/vhr10.py
@@ -473,7 +473,7 @@ class VHR10(NonGeoDataset):
             # Add masks
             if show_feats in {"masks", "both"} and "masks" in sample:
                 mask = masks[i]
-                contours = find_contours(mask, 0.5)  # _ type: ignore[no-untyped-call]
+                contours = find_contours(mask, 0.5)  # type: ignore[no-untyped-call]
                 for verts in contours:
                     verts = np.fliplr(verts)
                     p = patches.Polygon(
@@ -525,9 +525,7 @@ class VHR10(NonGeoDataset):
                 # Add masks
                 if show_pred_masks:
                     mask = prediction_masks[i]
-                    contours = find_contours(
-                        mask, 0.5
-                    )  # _ type: ignore[no-untyped-call]
+                    contours = find_contours(mask, 0.5)  # type: ignore[no-untyped-call]
                     for verts in contours:
                         verts = np.fliplr(verts)
                         p = patches.Polygon(


### PR DESCRIPTION
The documentation for the `is_image` and `dtype` properties of `RasterDataset` were vague in regards as to what to do for surface models, like DEMs. The changes proposed attempt to clarify how one should go about treating surface models for different circumstances when creating a custom model.